### PR TITLE
BUGFIX: Wrap long paths

### DIFF
--- a/Resources/Public/css/cachevisualisation.css
+++ b/Resources/Public/css/cachevisualisation.css
@@ -1,6 +1,7 @@
 .vivomedia-cachevisualisation {
   min-width: 20px;
   min-height: 20px;
+  word-wrap: break-word;
 }
 
 .vivomedia-cachevisualisation.vivomedia-cachevisualisation-cached {


### PR DESCRIPTION
Because fusion paths do not contain any spaces and can be fairly long,
they tend to flow outside of the visualisation container.