### PR TITLE
FEATURE: Display entry identifiers

### DIFF
--- a/Classes/Aspects/ContentCacheVisualisationAspect.php
+++ b/Classes/Aspects/ContentCacheVisualisationAspect.php
@@ -2,6 +2,7 @@
 
 namespace VIVOMEDIA\Fusion\CacheVisualisation\Aspects;
 
+use Neos\Cache\CacheAwareInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\JoinPointInterface;
 use Neos\Flow\ObjectManagement\Configuration\Configuration;
@@ -47,11 +48,26 @@ class ContentCacheVisualisationAspect
                 'path' => $path,
                 'tags' => implode(',', $joinPoint->getMethodArgument('tags')),
                 'lifetime' => $lifetime,
+                'identifiers' => $this->getCacheIdentifiers($joinPoint->getMethodArgument('cacheIdentifierValues')),
             ];
             $content = $this->_wrapContent(self::TYPE_CACHED, $content, $parameter);
 
             $joinPoint->setMethodArgument('content', $content);
         }
+    }
+
+    private function getCacheIdentifiers(array $cacheIdentifierValues)
+    {
+        $strings = array_map(
+            function($value) {
+                if ($value instanceof CacheAwareInterface) {
+                    return $value->getCacheEntryIdentifier();
+                }
+                return (string) $value;
+            },
+            $cacheIdentifierValues
+        );
+        return json_encode($strings);
     }
 
     private function _checkBlacklistedPath($path)


### PR DESCRIPTION
This adds a new field to the banner for the identifiers in use.
While the serialization logic is a bit different that the one used in `ContentCache::renderContentCacheEntryIdentifier` it should still give users a pretty good idea what each identifier is.

Example:
![Screenshot_2020-03-11_15-31-29](https://user-images.githubusercontent.com/3374170/76456637-a95a9780-63ad-11ea-81a0-f945b623b239.png)
