### PR TITLE
BUGFIX: Elongate page to allow scrolling down

### DIFF
--- a/Resources/Public/js/cachevisualisation.js
+++ b/Resources/Public/js/cachevisualisation.js
@@ -3,10 +3,13 @@ $(document).ready(function () {
   $('div[data-vivomedia-cache-visualisation]').hover(
     function() {
       var container = $( this );
+
+      $('body').css({ marginBottom: $('> .data-container', container).height() });
       $('> .data-container', container).show();
     },
     function(){
       var container = $( this );
+      $('body').css({ marginBottom: 0 });
       $('> .data-container', container).hide();
   });
 


### PR DESCRIPTION
Currently, the banner prevents users from inspecting cached areas at the
very bottom of the screen. This commit fixes the issue by elongating the
page by the height of the currently displayed banner.